### PR TITLE
Changed People tab on About page to have infinite scroll

### DIFF
--- a/src/modules/pece/pece_core/pece_core.views_default.inc
+++ b/src/modules/pece/pece_core/pece_core.views_default.inc
@@ -303,7 +303,7 @@ function pece_core_views_default_views() {
   $handler->display->display_options['defaults']['title'] = FALSE;
   $handler->display->display_options['title'] = 'People';
   $handler->display->display_options['defaults']['pager'] = FALSE;
-  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['type'] = 'infinite_scroll';
   $handler->display->display_options['pager']['options']['items_per_page'] = '10';
   $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['pager']['options']['id'] = '0';


### PR DESCRIPTION
The pager was causing the tab to revert from 'People' to 'About', so I changed it to an infinite scroll.